### PR TITLE
feat: Create @venok/testing package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,15 @@
         "rxjs": "catalog:",
       },
     },
+    "packages/testing": {
+      "name": "@venok/testing",
+      "version": "2.1.0",
+      "peerDependencies": {
+        "@venok/core": "workspace:*",
+        "reflect-metadata": "catalog:",
+        "rxjs": "catalog:",
+      },
+    },
     "packages/websocket": {
       "name": "@venok/websocket",
       "version": "2.1.0",
@@ -360,6 +369,8 @@
     "@venok/integration": ["@venok/integration@workspace:packages/integration"],
 
     "@venok/microservices": ["@venok/microservices@workspace:packages/microservices"],
+
+    "@venok/testing": ["@venok/testing@workspace:packages/testing"],
 
     "@venok/websocket": ["@venok/websocket@workspace:packages/websocket"],
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,7 @@ export * from "./helpers/validate-each.helper.js";
 export * from "./injector/injector.js";
 export * from "./injector/constants.js";
 export * from "./injector/container.js";
+export * from "./injector/instance/loader.js";
 export * from "./injector/instance/wrapper.js";
 export * from "./injector/internal-core-module/core-providers.js";
 export * from "./injector/module/lazy/loader.js";

--- a/packages/testing/bunfig.toml
+++ b/packages/testing/bunfig.toml
@@ -1,0 +1,7 @@
+[test]
+coverageSkipTestFiles = true  # default false
+preload = ["../../test-preload.ts"]
+coveragePathIgnorePatterns = [
+    "src/interfaces/**",
+    "../core/dist/**"
+]

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@venok/testing",
+  "version": "2.1.0",
+  "description": "",
+  "author": "shiz-ceo",
+  "type": "module",
+  "homepage": "",
+  "main": "index.js",
+  "files": [
+    "package.json",
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/venokjs/venok.git",
+    "directory": "packages/testing"
+  },
+  "scripts": {
+    "test": "bun test ./test/"
+  },
+  "peerDependencies": {
+    "@venok/core": "workspace:*",
+    "reflect-metadata": "catalog:",
+    "rxjs": "catalog:"
+  }
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line custom/sort-imports
+import "reflect-metadata";
+
+export * from "./interfaces/index.js";
+
+export * from "./testing/injector.js";
+export * from "./testing/instance-loader.js";
+export * from "./testing/logger.js";
+export * from "./testing/module-builder.js";
+export * from "./testing/noop-graph-inspector.js";
+export * from "./testing/testing.js";

--- a/packages/testing/src/interfaces/index.ts
+++ b/packages/testing/src/interfaces/index.ts
@@ -1,0 +1,4 @@
+export * from "./mock-factory.interface.js";
+export * from "./override-by.interface.js";
+export * from "./override-by-factory-options.interface.js";
+export * from "./override-module.interface.js";

--- a/packages/testing/src/interfaces/mock-factory.interface.ts
+++ b/packages/testing/src/interfaces/mock-factory.interface.ts
@@ -1,0 +1,3 @@
+import type { InjectionToken } from "@venok/core";
+
+export type MockFactory = (token?: InjectionToken) => any;

--- a/packages/testing/src/interfaces/override-by-factory-options.interface.ts
+++ b/packages/testing/src/interfaces/override-by-factory-options.interface.ts
@@ -1,0 +1,7 @@
+/**
+ * @publicApi
+ */
+export interface OverrideByFactoryOptions {
+  factory: (...args: any[]) => any;
+  inject?: any[];
+}

--- a/packages/testing/src/interfaces/override-by.interface.ts
+++ b/packages/testing/src/interfaces/override-by.interface.ts
@@ -1,0 +1,12 @@
+import type { OverrideByFactoryOptions } from "~/interfaces/override-by-factory-options.interface.js";
+import type { TestingModuleBuilder } from "~/testing/module-builder.js";
+
+
+/**
+ * @publicApi
+ */
+export interface OverrideBy {
+  useValue: (value: any) => TestingModuleBuilder;
+  useFactory: (options: OverrideByFactoryOptions) => TestingModuleBuilder;
+  useClass: (metatype: any) => TestingModuleBuilder;
+}

--- a/packages/testing/src/interfaces/override-module.interface.ts
+++ b/packages/testing/src/interfaces/override-module.interface.ts
@@ -1,0 +1,14 @@
+import type { ModuleDefinition } from "@venok/core";
+import type { TestingModuleBuilder } from "~/testing/module-builder.js";
+
+/**
+ * @publicApi
+ */
+export interface OverrideModule {
+  useModule: (newModule: ModuleDefinition) => TestingModuleBuilder;
+}
+
+export interface ModuleOverride {
+  moduleToReplace: ModuleDefinition;
+  newModule: ModuleDefinition;
+}

--- a/packages/testing/src/testing/injector.ts
+++ b/packages/testing/src/testing/injector.ts
@@ -1,0 +1,102 @@
+import type { InjectorDependencyContext } from "@venok/core";
+
+import type { MockFactory } from "~/interfaces/index.js";
+
+import { CoreModule, Injector, InstanceWrapper, STATIC_CONTEXT, VenokContainer } from "@venok/core";
+
+
+/**
+ * @publicApi
+ */
+export class TestingInjector extends Injector {
+  protected mocker?: MockFactory;
+  protected container!: VenokContainer;
+
+  public setMocker(mocker: MockFactory) {
+    this.mocker = mocker;
+  }
+
+  public setContainer(container: VenokContainer) {
+    this.container = container;
+  }
+
+  public async resolveComponentWrapper<T>(
+    moduleRef: CoreModule,
+    name: any,
+    dependencyContext: InjectorDependencyContext,
+    wrapper: InstanceWrapper<T>,
+    contextId = STATIC_CONTEXT,
+    inquirer?: InstanceWrapper,
+    keyOrIndex?: string | number
+  ): Promise<InstanceWrapper> {
+    try {
+      const existingProviderWrapper = await super.resolveComponentWrapper(
+        moduleRef,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        name,
+        dependencyContext,
+        wrapper,
+        contextId,
+        inquirer,
+        keyOrIndex
+      );
+      return existingProviderWrapper;
+    } catch (err) {
+      return this.mockWrapper(err, moduleRef, name, wrapper);
+    }
+  }
+
+  public async resolveComponentHost<T>(
+    moduleRef: CoreModule,
+    instanceWrapper: InstanceWrapper<T>,
+    contextId = STATIC_CONTEXT,
+    inquirer?: InstanceWrapper
+  ): Promise<InstanceWrapper> {
+    try {
+      const existingProviderWrapper = await super.resolveComponentHost(
+        moduleRef,
+        instanceWrapper,
+        contextId,
+        inquirer
+      );
+      return existingProviderWrapper;
+    } catch (err) {
+      return this.mockWrapper(err, moduleRef, instanceWrapper.name, instanceWrapper);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  private async mockWrapper<T>(
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+    err: Error | unknown,
+    moduleRef: CoreModule,
+    name: any,
+    wrapper: InstanceWrapper<T>
+  ): Promise<InstanceWrapper> {
+    if (!this.mocker) throw err;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const mockedInstance = this.mocker(name);
+    if (!mockedInstance) throw err;
+
+    const newWrapper = new InstanceWrapper({
+      name,
+      isAlias: false,
+      scope: wrapper.scope,
+      instance: mockedInstance,
+      isResolved: true,
+      host: moduleRef,
+      metatype: wrapper.metatype,
+    });
+    const internalCoreModule = this.container.getInternalCoreModuleRef();
+    if (!internalCoreModule) throw new Error("Expected to have internal core module reference at this point.");
+
+    internalCoreModule.addCustomProvider(
+      { provide: name, useValue: mockedInstance },
+      internalCoreModule.providers
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    internalCoreModule.addExportedProviderOrModule(name);
+    return newWrapper;
+  }
+}

--- a/packages/testing/src/testing/instance-loader.ts
+++ b/packages/testing/src/testing/instance-loader.ts
@@ -1,0 +1,18 @@
+import type { CoreModule } from "@venok/core";
+
+import type { TestingInjector } from "~/testing/injector.js";
+import type { MockFactory } from "~/interfaces/index.js";
+
+import { InstanceLoader } from "@venok/core";
+
+export class TestingInstanceLoader extends InstanceLoader<TestingInjector> {
+  public async createInstancesOfDependencies(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    modules: Map<string, CoreModule> = this.container.getModules(),
+    mocker?: MockFactory
+  ): Promise<void> {
+    this.injector.setContainer(this.container);
+    mocker && this.injector.setMocker(mocker);
+    await super.createInstancesOfDependencies();
+  }
+}

--- a/packages/testing/src/testing/logger.ts
+++ b/packages/testing/src/testing/logger.ts
@@ -1,0 +1,23 @@
+import { ConsoleLogger } from "@venok/core";
+
+/**
+ * @publicApi
+ */
+export class TestingLogger extends ConsoleLogger {
+  constructor() {
+    super("Testing");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  log(message: string) {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  warn(message: string) {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  debug(message: string) {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  verbose(message: string) {}
+  error(message: string, ...optionalParams: any[]) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    return super.error(message, ...optionalParams);
+  }
+}

--- a/packages/testing/src/testing/module-builder.ts
+++ b/packages/testing/src/testing/module-builder.ts
@@ -1,0 +1,159 @@
+import type { ApplicationContextOptions, LoggerService, ModuleDefinition, ModuleMetadata } from "@venok/core";
+
+import type { MockFactory, ModuleOverride, OverrideBy, OverrideByFactoryOptions, OverrideModule } from "~/interfaces/index.js";
+
+import {
+  ApplicationConfig,
+  ApplicationContext,
+  ConsoleLogger,
+  DependenciesScanner,
+  GraphInspector,
+  Logger,
+  MetadataScanner,
+  Module,
+  UuidFactory,
+  UuidFactoryMode,
+  VenokContainer
+} from "@venok/core";
+
+import { TestingInjector } from "~/testing/injector.js";
+import { TestingInstanceLoader } from "~/testing/instance-loader.js";
+import { TestingLogger } from "~/testing/logger.js";
+import { NoopGraphInspector } from "./noop-graph-inspector.js";
+
+/**
+ * @publicApi
+ */
+export class TestingModuleBuilder {
+  private readonly applicationConfig = new ApplicationConfig();
+  private readonly container: VenokContainer;
+  private readonly overloadsMap = new Map();
+  private readonly moduleOverloadsMap = new Map<ModuleDefinition, ModuleDefinition>();
+  private readonly module: any;
+  private testingLogger!: LoggerService;
+  private mocker?: MockFactory;
+
+  constructor(
+    private readonly metadataScanner: MetadataScanner,
+    metadata: ModuleMetadata
+  ) {
+    this.container = new VenokContainer(this.applicationConfig);
+    this.module = this.createModule(metadata);
+  }
+
+  public setLogger(testingLogger: LoggerService) {
+    this.testingLogger = testingLogger;
+    return this;
+  }
+
+  public overridePipe<T = any>(typeOrToken: T): OverrideBy {
+    return this.override(typeOrToken, false);
+  }
+
+  public useMocker(mocker: MockFactory): TestingModuleBuilder {
+    this.mocker = mocker;
+    return this;
+  }
+
+  public overrideFilter<T = any>(typeOrToken: T): OverrideBy {
+    return this.override(typeOrToken, false);
+  }
+
+  public overrideGuard<T = any>(typeOrToken: T): OverrideBy {
+    return this.override(typeOrToken, false);
+  }
+
+  public overrideInterceptor<T = any>(typeOrToken: T): OverrideBy {
+    return this.override(typeOrToken, false);
+  }
+
+  public overrideProvider<T = any>(typeOrToken: T): OverrideBy {
+    return this.override(typeOrToken, true);
+  }
+
+  public overrideModule(moduleToOverride: ModuleDefinition): OverrideModule {
+    return {
+      useModule: newModule => {
+        this.moduleOverloadsMap.set(moduleToOverride, newModule);
+        return this;
+      },
+    };
+  }
+
+  public async compile(options: Pick<ApplicationContextOptions, "snapshot" | "preview"> = {}): Promise<ApplicationContext> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const nest: any = require("@nestjs/common");
+      if (nest) nest.Logger.overrideLogger(new ConsoleLogger());
+    } catch { /* empty */ }
+    
+    this.applyLogger();
+
+    UuidFactory.mode = options?.snapshot ? UuidFactoryMode.Deterministic : UuidFactoryMode.Random;
+    const graphInspector: GraphInspector = options?.snapshot ? new GraphInspector(this.container) : NoopGraphInspector;
+
+    const scanner = new DependenciesScanner(this.container, this.metadataScanner, graphInspector, this.applicationConfig);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    await scanner.scan(this.module, { overrides: this.getModuleOverloads() });
+
+    this.applyOverloadsMap();
+    await this.createInstancesOfDependencies(graphInspector, options);
+    scanner.applyApplicationProviders();
+
+    const root = this.getRootModule();
+    return new ApplicationContext(this.container, this.applicationConfig, options, root);
+  }
+
+  private override<T = any>(typeOrToken: T, isProvider: boolean): OverrideBy {
+    const addOverload = (options: any) => {
+      this.overloadsMap.set(typeOrToken, { ...options, isProvider });
+      return this;
+    };
+    return this.createOverrideByBuilder(addOverload);
+  }
+
+  private createOverrideByBuilder(add: (provider: any) => TestingModuleBuilder): OverrideBy {
+    return {
+      useValue: value => add({ useValue: value }),
+      useFactory: (options: OverrideByFactoryOptions) => add({ ...options, useFactory: options.factory }),
+      useClass: metatype => add({ useClass: metatype }),
+    };
+  }
+
+  private applyOverloadsMap() {
+    const overloads = [...this.overloadsMap.entries()];
+    overloads.forEach(([item, options]) => this.container.replace(item, options));
+  }
+
+  private getModuleOverloads(): ModuleOverride[] {
+    const overloads = [...this.moduleOverloadsMap.entries()];
+    return overloads.map(([moduleToReplace, newModule]) => ({
+      moduleToReplace,
+      newModule,
+    }));
+  }
+
+  private getRootModule() {
+    const modules = this.container.getModules().values();
+    return modules.next().value!;
+  }
+
+  private async createInstancesOfDependencies(
+    graphInspector: GraphInspector,
+    options: { preview?: boolean }
+  ) {
+    const injector = new TestingInjector({ preview: options?.preview ?? false });
+    const instanceLoader = new TestingInstanceLoader(this.container, injector, graphInspector);
+    await instanceLoader.createInstancesOfDependencies(this.container.getModules(), this.mocker);
+  }
+
+  private createModule(metadata: ModuleMetadata) {
+    class RootTestModule {}
+    Module(metadata)(RootTestModule);
+    return RootTestModule;
+  }
+
+  private applyLogger() {
+    Logger.overrideLogger(this.testingLogger || new TestingLogger());
+  }
+}

--- a/packages/testing/src/testing/noop-graph-inspector.ts
+++ b/packages/testing/src/testing/noop-graph-inspector.ts
@@ -1,0 +1,5 @@
+import { GraphInspector } from "@venok/core";
+
+
+const noop = () => {};
+export const NoopGraphInspector: GraphInspector = new Proxy(GraphInspector.prototype, { get: () => noop });

--- a/packages/testing/src/testing/testing.ts
+++ b/packages/testing/src/testing/testing.ts
@@ -1,0 +1,13 @@
+import type { ModuleMetadata } from "@venok/core";
+
+import { MetadataScanner } from "@venok/core";
+
+import { TestingModuleBuilder } from "~/testing/module-builder.js";
+
+export class Test {
+  private static readonly metadataScanner = new MetadataScanner();
+
+  public static createTestingModule(metadata: ModuleMetadata) {
+    return new TestingModuleBuilder(this.metadataScanner, metadata);
+  }
+}

--- a/packages/testing/test/testing/injector.test.ts
+++ b/packages/testing/test/testing/injector.test.ts
@@ -1,0 +1,406 @@
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { CoreModule, Injector, InstanceWrapper, Scope, STATIC_CONTEXT, VenokContainer } from "@venok/core";
+
+import { TestingInjector } from "~/testing/injector.js";
+
+describe("TestingInjector", () => {
+  let testingInjector: TestingInjector;
+  let mockContainer: VenokContainer;
+  let mockCoreModule: CoreModule;
+  let mockInstanceWrapper: InstanceWrapper;
+
+  beforeEach(() => {
+    testingInjector = new TestingInjector();
+    mockContainer = new VenokContainer();
+    mockCoreModule = new CoreModule(class TestModule {}, mockContainer);
+    mockInstanceWrapper = new InstanceWrapper({
+      name: "TestService",
+      metatype: class TestService {},
+      instance: null,
+      isResolved: false,
+    });
+  });
+
+  describe("setMocker", () => {
+    it("should set the mocker function", () => {
+      const mockFactory = mock();
+      testingInjector.setMocker(mockFactory);
+      
+      expect((testingInjector as any).mocker).toBe(mockFactory);
+    });
+  });
+
+  describe("setContainer", () => {
+    it("should set the container", () => {
+      testingInjector.setContainer(mockContainer);
+      
+      expect((testingInjector as any).container).toBe(mockContainer);
+    });
+  });
+
+  describe("resolveComponentWrapper", () => {
+    beforeEach(() => {
+      testingInjector.setContainer(mockContainer);
+    });
+
+    describe("when super.resolveComponentWrapper succeeds", () => {
+      it("should return the resolved wrapper from parent injector", async () => {
+        const expectedWrapper = new InstanceWrapper({
+          name: "ResolvedService",
+          instance: {},
+          isResolved: true,
+        });
+
+        const superResolveComponentWrapper = spyOn(
+          Injector.prototype, 
+          "resolveComponentWrapper"
+        ).mockResolvedValue(expectedWrapper);
+
+        const result = await testingInjector.resolveComponentWrapper(
+          mockCoreModule,
+          "TestService",
+          { index: 0, dependencies: [] },
+          mockInstanceWrapper
+        );
+
+        expect(superResolveComponentWrapper).toHaveBeenCalledWith(
+          mockCoreModule,
+          "TestService",
+          { index: 0, dependencies: [] },
+          mockInstanceWrapper,
+          STATIC_CONTEXT,
+          undefined,
+          undefined
+        );
+        expect(result).toBe(expectedWrapper);
+      });
+    });
+
+    describe("when super.resolveComponentWrapper fails", () => {
+      it("should call mockWrapper when error is thrown and mocker is set", async () => {
+        const error = new Error("Dependency not found");
+        const mockedInstance = { mocked: true };
+        const mockFactory = mock(() => mockedInstance);
+        
+        testingInjector.setMocker(mockFactory);
+
+        spyOn(Injector.prototype, "resolveComponentWrapper").mockRejectedValue(error);
+        
+        const mockInternalCoreModule = {
+          addCustomProvider: mock(),
+          addExportedProviderOrModule: mock(),
+          providers: new Map(),
+        };
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        spyOn(mockContainer, "getInternalCoreModuleRef").mockReturnValue(mockInternalCoreModule as any);
+
+        const result = await testingInjector.resolveComponentWrapper(
+          mockCoreModule,
+          "TestService",
+          { index: 0, dependencies: [] },
+          mockInstanceWrapper
+        );
+
+        expect(mockFactory).toHaveBeenCalledWith("TestService");
+        expect(result).toBeInstanceOf(InstanceWrapper);
+        expect(result.instance).toBe(mockedInstance);
+        expect(result.getInstanceByContextId(STATIC_CONTEXT).isResolved).toBe(true);
+        expect(mockInternalCoreModule.addCustomProvider).toHaveBeenCalledWith(
+          { provide: "TestService", useValue: mockedInstance },
+          mockInternalCoreModule.providers
+        );
+        expect(mockInternalCoreModule.addExportedProviderOrModule).toHaveBeenCalledWith("TestService");
+      });
+
+      it("should throw original error when no mocker is set", async () => {
+        const error = new Error("Dependency not found");
+        spyOn(Injector.prototype, "resolveComponentWrapper").mockRejectedValue(error);
+
+        expect(testingInjector.resolveComponentWrapper(
+          mockCoreModule,
+          "TestService",
+          { index: 0, dependencies: [] },
+          mockInstanceWrapper
+        )).rejects.toThrow(error);
+      });
+
+      it("should throw original error when mocker returns null", async () => {
+        const error = new Error("Dependency not found");
+        const mockFactory = mock(() => null);
+        
+        testingInjector.setMocker(mockFactory);
+        spyOn(Injector.prototype, "resolveComponentWrapper").mockRejectedValue(error);
+
+        expect(testingInjector.resolveComponentWrapper(
+          mockCoreModule,
+          "TestService",
+          { index: 0, dependencies: [] },
+          mockInstanceWrapper
+        )).rejects.toThrow(error);
+      });
+
+      it("should throw original error when mocker returns undefined", async () => {
+        const error = new Error("Dependency not found");
+        const mockFactory = mock(() => undefined);
+        
+        testingInjector.setMocker(mockFactory);
+        spyOn(Injector.prototype, "resolveComponentWrapper").mockRejectedValue(error);
+
+        expect(testingInjector.resolveComponentWrapper(
+          mockCoreModule,
+          "TestService",
+          { index: 0, dependencies: [] },
+          mockInstanceWrapper
+        )).rejects.toThrow(error);
+      });
+
+      it("should throw error when internal core module is not available", async () => {
+        const error = new Error("Dependency not found");
+        const mockFactory = mock(() => ({ mocked: true }));
+        
+        testingInjector.setMocker(mockFactory);
+        spyOn(Injector.prototype, "resolveComponentWrapper").mockRejectedValue(error);
+        spyOn(mockContainer, "getInternalCoreModuleRef").mockReturnValue(undefined);
+
+        expect(testingInjector.resolveComponentWrapper(
+          mockCoreModule,
+          "TestService",
+          { index: 0, dependencies: [] },
+          mockInstanceWrapper
+        )).rejects.toThrow("Expected to have internal core module reference at this point.");
+      });
+    });
+  });
+
+  describe("resolveComponentHost", () => {
+    beforeEach(() => {
+      testingInjector.setContainer(mockContainer);
+    });
+
+    describe("when super.resolveComponentHost succeeds", () => {
+      it("should return the resolved wrapper from parent injector", async () => {
+        const expectedWrapper = new InstanceWrapper({
+          name: "ResolvedService",
+          instance: {},
+          isResolved: true,
+        });
+
+        const superResolveComponentHost = spyOn(
+          Injector.prototype, 
+          "resolveComponentHost"
+        ).mockResolvedValue(expectedWrapper);
+
+        const result = await testingInjector.resolveComponentHost(
+          mockCoreModule,
+          mockInstanceWrapper
+        );
+
+        expect(superResolveComponentHost).toHaveBeenCalledWith(
+          mockCoreModule,
+          mockInstanceWrapper,
+          STATIC_CONTEXT,
+          undefined
+        );
+        expect(result).toBe(expectedWrapper);
+      });
+    });
+
+    describe("when super.resolveComponentHost fails", () => {
+      it("should call mockWrapper when error is thrown and mocker is set", async () => {
+        const error = new Error("Component not found");
+        const mockedInstance = { mocked: true };
+        const mockFactory = mock(() => mockedInstance);
+        
+        testingInjector.setMocker(mockFactory);
+
+        spyOn(Injector.prototype, "resolveComponentHost").mockRejectedValue(error);
+        
+        const mockInternalCoreModule = {
+          addCustomProvider: mock(),
+          addExportedProviderOrModule: mock(),
+          providers: new Map(),
+        };
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        spyOn(mockContainer, "getInternalCoreModuleRef").mockReturnValue(mockInternalCoreModule as any);
+
+        const result = await testingInjector.resolveComponentHost(
+          mockCoreModule,
+          mockInstanceWrapper
+        );
+
+        expect(mockFactory).toHaveBeenCalledWith(mockInstanceWrapper.name);
+        expect(result).toBeInstanceOf(InstanceWrapper);
+        expect(result.instance).toBe(mockedInstance);
+        expect(result.getInstanceByContextId(STATIC_CONTEXT).isResolved).toBe(true);
+        expect(mockInternalCoreModule.addCustomProvider).toHaveBeenCalledWith(
+          { provide: mockInstanceWrapper.name, useValue: mockedInstance },
+          mockInternalCoreModule.providers
+        );
+        expect(mockInternalCoreModule.addExportedProviderOrModule).toHaveBeenCalledWith(mockInstanceWrapper.name);
+      });
+
+      it("should throw original error when no mocker is set", async () => {
+        const error = new Error("Component not found");
+        spyOn(Injector.prototype, "resolveComponentHost").mockRejectedValue(error);
+
+        expect(testingInjector.resolveComponentHost(
+          mockCoreModule,
+          mockInstanceWrapper
+        )).rejects.toThrow(error);
+      });
+    });
+  });
+
+  describe("mockWrapper", () => {
+    let mockInternalCoreModule: any;
+
+    beforeEach(() => {
+      testingInjector.setContainer(mockContainer);
+      mockInternalCoreModule = {
+        addCustomProvider: mock(),
+        addExportedProviderOrModule: mock(),
+        providers: new Map(),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      spyOn(mockContainer, "getInternalCoreModuleRef").mockReturnValue(mockInternalCoreModule);
+    });
+
+    it("should create a new wrapper with mocked instance", async () => {
+      const error = new Error("Test error");
+      const mockedInstance = { mocked: true };
+      const mockFactory = mock(() => mockedInstance);
+      
+      testingInjector.setMocker(mockFactory);
+
+      const result = await (testingInjector as any).mockWrapper(
+        error,
+        mockCoreModule,
+        "TestService",
+        mockInstanceWrapper
+      );
+
+      expect(mockFactory).toHaveBeenCalledWith("TestService");
+      expect(result).toBeInstanceOf(InstanceWrapper);
+      expect(result.name).toBe("TestService");
+      expect(result.instance).toBe(mockedInstance);
+      expect(result.getInstanceByContextId(STATIC_CONTEXT).isResolved).toBe(true);
+      expect(result.host).toBe(mockCoreModule);
+      expect(result.metatype).toBe(mockInstanceWrapper.metatype);
+      expect(result.scope).toBe(mockInstanceWrapper.scope);
+    });
+
+    it("should add the mocked instance to the internal core module", async () => {
+      const error = new Error("Test error");
+      const mockedInstance = { mocked: true };
+      const mockFactory = mock(() => mockedInstance);
+      
+      testingInjector.setMocker(mockFactory);
+
+      await (testingInjector as any).mockWrapper(
+        error,
+        mockCoreModule,
+        "TestService",
+        mockInstanceWrapper
+      );
+
+      expect(mockInternalCoreModule.addCustomProvider).toHaveBeenCalledWith(
+        { provide: "TestService", useValue: mockedInstance },
+        mockInternalCoreModule.providers
+      );
+      expect(mockInternalCoreModule.addExportedProviderOrModule).toHaveBeenCalledWith("TestService");
+    });
+
+    it("should preserve wrapper properties in the new wrapper", async () => {
+      const error = new Error("Test error");
+      const mockedInstance = { mocked: true };
+      const mockFactory = mock(() => mockedInstance);
+      
+      testingInjector.setMocker(mockFactory);
+
+      const customWrapper = new InstanceWrapper({
+        name: "CustomService",
+        metatype: class CustomService {},
+        scope: Scope.DEFAULT,
+        instance: null,
+        isResolved: false,
+      });
+
+      const result = await (testingInjector as any).mockWrapper(
+        error,
+        mockCoreModule,
+        "CustomService",
+        customWrapper
+      );
+
+      expect(result.scope).toBe(Scope.DEFAULT);
+      expect(result.metatype).toBe(customWrapper.metatype);
+    });
+  });
+
+  describe("integration scenarios", () => {
+    let moduleWithDeps: CoreModule;
+    let serviceWrapper: InstanceWrapper;
+    let dependencyWrapper: InstanceWrapper;
+
+    beforeEach(() => {
+      testingInjector.setContainer(mockContainer);
+      
+      moduleWithDeps = new CoreModule(class ModuleWithDeps {}, mockContainer);
+      
+      serviceWrapper = new InstanceWrapper({
+        name: "ServiceWithDeps",
+        metatype: class ServiceWithDeps {},
+        instance: null,
+        isResolved: false,
+      });
+      
+      dependencyWrapper = new InstanceWrapper({
+        name: "Dependency",
+        metatype: class Dependency {},
+        instance: null,
+        isResolved: false,
+      });
+
+      moduleWithDeps.providers.set("ServiceWithDeps", serviceWrapper);
+      moduleWithDeps.providers.set("Dependency", dependencyWrapper);
+    });
+
+    it("should successfully mock dependencies when resolution fails", async () => {
+      const mockedDependency = { mocked: "dependency" };
+      const mockFactory = mock((token) => {
+        if (token === "Dependency") return mockedDependency;
+        return null;
+      });
+      
+      testingInjector.setMocker(mockFactory);
+      
+      const mockInternalCoreModule = {
+        addCustomProvider: mock(),
+        addExportedProviderOrModule: mock(),
+        providers: new Map(),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      spyOn(mockContainer, "getInternalCoreModuleRef").mockReturnValue(mockInternalCoreModule as any);
+
+      spyOn(Injector.prototype, "resolveComponentWrapper").mockImplementation((moduleRef, name, depContext, wrapper) => {
+        if (name === "Dependency") throw new Error("Dependency not found");
+
+        return Promise.resolve(wrapper);
+      });
+
+      const result = await testingInjector.resolveComponentWrapper(
+        moduleWithDeps,
+        "Dependency",
+        { index: 0, dependencies: [] },
+        dependencyWrapper
+      );
+
+      expect(mockFactory).toHaveBeenCalledWith("Dependency");
+      expect(result.instance).toBe(mockedDependency);
+      expect(mockInternalCoreModule.addCustomProvider).toHaveBeenCalledWith(
+        { provide: "Dependency", useValue: mockedDependency },
+        mockInternalCoreModule.providers
+      );
+    });
+  });
+});

--- a/packages/testing/test/testing/module-builder.test.ts
+++ b/packages/testing/test/testing/module-builder.test.ts
@@ -1,0 +1,452 @@
+import type { LoggerService, ModuleMetadata } from "@venok/core";
+
+import {
+  ApplicationConfig,
+  ApplicationContext,
+  DependenciesScanner,
+  Logger,
+  MetadataScanner,
+  Module,
+  UuidFactory,
+  VenokContainer
+} from "@venok/core";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+
+import { TestingModuleBuilder } from "~/testing/module-builder.js";
+import { TestingInstanceLoader } from "~/testing/instance-loader.js";
+import { TestingLogger } from "~/testing/logger.js";
+
+describe("TestingModuleBuilder", () => {
+  let metadataScanner: MetadataScanner;
+  let testingModuleBuilder: TestingModuleBuilder;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let mockModule: any;
+
+  const mockMetadata: ModuleMetadata = {
+    providers: [],
+    imports: [],
+    exports: [],
+  };
+
+  beforeEach(() => {
+    metadataScanner = new MetadataScanner();
+    testingModuleBuilder = new TestingModuleBuilder(metadataScanner, mockMetadata);
+    
+    @Module({})
+    class TestModule {}
+    mockModule = TestModule;
+  });
+
+  afterEach(() => {
+    // No cleanup needed for bun test
+  });
+
+  describe("constructor", () => {
+    it("should create instance with correct properties", () => {
+      expect(testingModuleBuilder).toBeInstanceOf(TestingModuleBuilder);
+      expect((testingModuleBuilder as any).metadataScanner).toBe(metadataScanner);
+      expect((testingModuleBuilder as any).applicationConfig).toBeInstanceOf(ApplicationConfig);
+      expect((testingModuleBuilder as any).container).toBeInstanceOf(VenokContainer);
+      expect((testingModuleBuilder as any).overloadsMap).toBeInstanceOf(Map);
+      expect((testingModuleBuilder as any).moduleOverloadsMap).toBeInstanceOf(Map);
+    });
+
+    it("should create module from metadata", () => {
+      const module = (testingModuleBuilder as any).module;
+      expect(module).toBeDefined();
+      expect(typeof module).toBe("function");
+    });
+  });
+
+  describe("setLogger", () => {
+    it("should set custom logger and return builder instance", () => {
+      const customLogger: LoggerService = {
+        log: () => {},
+        error: () => {},
+        warn: () => {},
+        debug: () => {},
+        verbose: () => {},
+      };
+
+      const result = testingModuleBuilder.setLogger(customLogger);
+      
+      expect(result).toBe(testingModuleBuilder);
+      expect((testingModuleBuilder as any).testingLogger).toBe(customLogger);
+    });
+  });
+
+  describe("override methods", () => {
+    class TestProvider {}
+
+    it("should create override for pipe", () => {
+      const overrideBy = testingModuleBuilder.overridePipe(TestProvider);
+      
+      expect(overrideBy).toHaveProperty("useValue");
+      expect(overrideBy).toHaveProperty("useFactory");
+      expect(overrideBy).toHaveProperty("useClass");
+      expect(typeof overrideBy.useValue).toBe("function");
+      expect(typeof overrideBy.useFactory).toBe("function");
+      expect(typeof overrideBy.useClass).toBe("function");
+    });
+
+    it("should create override for filter", () => {
+      const overrideBy = testingModuleBuilder.overrideFilter(TestProvider);
+      
+      expect(overrideBy).toHaveProperty("useValue");
+      expect(overrideBy).toHaveProperty("useFactory");
+      expect(overrideBy).toHaveProperty("useClass");
+    });
+
+    it("should create override for guard", () => {
+      const overrideBy = testingModuleBuilder.overrideGuard(TestProvider);
+      
+      expect(overrideBy).toHaveProperty("useValue");
+      expect(overrideBy).toHaveProperty("useFactory");
+      expect(overrideBy).toHaveProperty("useClass");
+    });
+
+    it("should create override for interceptor", () => {
+      const overrideBy = testingModuleBuilder.overrideInterceptor(TestProvider);
+      
+      expect(overrideBy).toHaveProperty("useValue");
+      expect(overrideBy).toHaveProperty("useFactory");
+      expect(overrideBy).toHaveProperty("useClass");
+    });
+
+    it("should create override for provider", () => {
+      const overrideBy = testingModuleBuilder.overrideProvider(TestProvider);
+      
+      expect(overrideBy).toHaveProperty("useValue");
+      expect(overrideBy).toHaveProperty("useFactory");
+      expect(overrideBy).toHaveProperty("useClass");
+    });
+
+    describe("useValue", () => {
+      it("should add override with useValue and return builder", () => {
+        const mockValue = { test: "value" };
+        
+        const result = testingModuleBuilder.overrideProvider(TestProvider).useValue(mockValue);
+        
+        expect(result).toBe(testingModuleBuilder);
+        
+        const overloadsMap = (testingModuleBuilder as any).overloadsMap;
+        expect(overloadsMap.has(TestProvider)).toBe(true);
+        expect(overloadsMap.get(TestProvider)).toEqual({
+          useValue: mockValue,
+          isProvider: true,
+        });
+      });
+    });
+
+    describe("useClass", () => {
+      it("should add override with useClass and return builder", () => {
+        class MockClass {}
+        
+        const result = testingModuleBuilder.overrideProvider(TestProvider).useClass(MockClass);
+        
+        expect(result).toBe(testingModuleBuilder);
+        
+        const overloadsMap = (testingModuleBuilder as any).overloadsMap;
+        expect(overloadsMap.has(TestProvider)).toBe(true);
+        expect(overloadsMap.get(TestProvider)).toEqual({
+          useClass: MockClass,
+          isProvider: true,
+        });
+      });
+    });
+
+    describe("useFactory", () => {
+      it("should add override with useFactory and return builder", () => {
+        const mockFactory = () => ({ test: "factory" });
+        const inject = ["DEPENDENCY"];
+        
+        const result = testingModuleBuilder.overrideProvider(TestProvider).useFactory({
+          factory: mockFactory,
+          inject,
+        });
+        
+        expect(result).toBe(testingModuleBuilder);
+        
+        const overloadsMap = (testingModuleBuilder as any).overloadsMap;
+        expect(overloadsMap.has(TestProvider)).toBe(true);
+        const override = overloadsMap.get(TestProvider);
+        expect(override.useFactory).toBe(mockFactory);
+        expect(override.inject).toEqual(inject);
+        expect(override.isProvider).toBe(true);
+      });
+    });
+
+    it("should distinguish between provider and non-provider overrides", () => {
+      const mockValue = { test: "value" };
+      
+      testingModuleBuilder.overrideProvider(TestProvider).useValue(mockValue);
+      testingModuleBuilder.overridePipe("PIPE_TOKEN").useValue(mockValue);
+      
+      const overloadsMap = (testingModuleBuilder as any).overloadsMap;
+      
+      expect(overloadsMap.get(TestProvider).isProvider).toBe(true);
+      expect(overloadsMap.get("PIPE_TOKEN").isProvider).toBe(false);
+    });
+  });
+
+  describe("overrideModule", () => {
+    it("should create module override and return OverrideModule interface", () => {
+      @Module({})
+      class OriginalModule {}
+      
+      const overrideModule = testingModuleBuilder.overrideModule(OriginalModule);
+      
+      expect(overrideModule).toHaveProperty("useModule");
+      expect(typeof overrideModule.useModule).toBe("function");
+    });
+
+    it("should add module override when useModule is called", () => {
+      @Module({})
+      class OriginalModule {}
+      
+      @Module({})
+      class ReplacementModule {}
+      
+      const result = testingModuleBuilder.overrideModule(OriginalModule).useModule(ReplacementModule);
+      
+      expect(result).toBe(testingModuleBuilder);
+      
+      const moduleOverloadsMap = (testingModuleBuilder as any).moduleOverloadsMap;
+      expect(moduleOverloadsMap.has(OriginalModule)).toBe(true);
+      expect(moduleOverloadsMap.get(OriginalModule)).toBe(ReplacementModule);
+    });
+  });
+
+  describe("useMocker", () => {
+    it("should set mocker and return builder instance", () => {
+      const mockFactory = (token?: any) => ({ mocked: token });
+      
+      const result = testingModuleBuilder.useMocker(mockFactory);
+      
+      expect(result).toBe(testingModuleBuilder);
+      expect((testingModuleBuilder as any).mocker).toBe(mockFactory);
+    });
+  });
+
+  describe("compile", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let consoleLoggerSpy: any;
+    let loggerOverrideSpy: any;
+    let scannerScanSpy: any;
+    let instanceLoaderSpy: any;
+
+    beforeEach(() => {
+      consoleLoggerSpy = spyOn(Logger, "overrideLogger");
+      loggerOverrideSpy = spyOn(Logger, "overrideLogger");
+      scannerScanSpy = spyOn(DependenciesScanner.prototype, "scan").mockResolvedValue(undefined);
+      instanceLoaderSpy = spyOn(TestingInstanceLoader.prototype, "createInstancesOfDependencies").mockResolvedValue(undefined);
+      spyOn(DependenciesScanner.prototype, "applyApplicationProviders").mockReturnValue(undefined);
+    });
+
+    it("should compile testing module with default options", async () => {
+      const context = await testingModuleBuilder.compile();
+      
+      expect(context).toBeInstanceOf(ApplicationContext);
+      expect(scannerScanSpy).toHaveBeenCalledWith(
+        (testingModuleBuilder as any).module,
+        { overrides: [] }
+      );
+    });
+
+    it("should set UUID factory mode based on snapshot option", async () => {
+      // DeterministicUuidRegistry needs to be cleared to get consistent results
+      const { DeterministicUuidRegistry } = await import("@venok/core");
+      
+      DeterministicUuidRegistry.clear();
+      await testingModuleBuilder.compile({ snapshot: true });
+      const deterministicUuid1 = UuidFactory.get("test");
+      
+      DeterministicUuidRegistry.clear();
+      await testingModuleBuilder.compile({ snapshot: true });
+      const deterministicUuid2 = UuidFactory.get("test");
+      // Deterministic mode should produce the same UUID for the same key when registry is clear
+      expect(deterministicUuid1).toBe(deterministicUuid2);
+      
+      await testingModuleBuilder.compile({ snapshot: false });
+      const randomUuid1 = UuidFactory.get();
+      const randomUuid2 = UuidFactory.get();
+      // Random mode should produce different UUIDs
+      expect(randomUuid1).not.toBe(randomUuid2);
+    });
+
+    it("should use GraphInspector when snapshot is true", async () => {
+      const context = await testingModuleBuilder.compile({ snapshot: true });
+      
+      expect(context).toBeInstanceOf(ApplicationContext);
+    });
+
+    it("should use NoopGraphInspector when snapshot is false", async () => {
+      const context = await testingModuleBuilder.compile({ snapshot: false });
+      
+      expect(context).toBeInstanceOf(ApplicationContext);
+    });
+
+    it("should apply custom logger when set", async () => {
+      const customLogger: LoggerService = {
+        log: () => {},
+        error: () => {},
+        warn: () => {},
+        debug: () => {},
+        verbose: () => {},
+      };
+      
+      testingModuleBuilder.setLogger(customLogger);
+      await testingModuleBuilder.compile();
+      
+      expect(loggerOverrideSpy).toHaveBeenCalledWith(customLogger);
+    });
+
+    it("should use default TestingLogger when no custom logger is set", async () => {
+      await testingModuleBuilder.compile();
+      
+      expect(loggerOverrideSpy).toHaveBeenCalledWith(expect.any(TestingLogger));
+    });
+
+    it("should pass preview option to instance loader", async () => {
+      await testingModuleBuilder.compile({ preview: true });
+      
+      expect(instanceLoaderSpy).toHaveBeenCalledWith(
+        expect.any(Map),
+        undefined
+      );
+    });
+
+    it("should apply overloads to container", async () => {
+      const mockValue = { test: "value" };
+      
+      testingModuleBuilder.overrideProvider("TEST_TOKEN").useValue(mockValue);
+      
+      const replaceSpy = spyOn(VenokContainer.prototype, "replace");
+      
+      await testingModuleBuilder.compile();
+      
+      expect(replaceSpy).toHaveBeenCalledWith("TEST_TOKEN", {
+        useValue: mockValue,
+        isProvider: true,
+      });
+    });
+
+    it("should pass module overrides to scanner", async () => {
+      @Module({})
+      class OriginalModule {}
+      
+      @Module({})
+      class ReplacementModule {}
+      
+      testingModuleBuilder.overrideModule(OriginalModule).useModule(ReplacementModule);
+      
+      await testingModuleBuilder.compile();
+      
+      expect(scannerScanSpy).toHaveBeenCalledWith(
+        (testingModuleBuilder as any).module,
+        {
+          overrides: [
+            {
+              moduleToReplace: OriginalModule,
+              newModule: ReplacementModule,
+            },
+          ],
+        }
+      );
+    });
+
+    it("should pass mocker to instance loader", async () => {
+      const mockFactory = (token?: any) => ({ mocked: token });
+      
+      testingModuleBuilder.useMocker(mockFactory);
+      
+      await testingModuleBuilder.compile();
+      
+      expect(instanceLoaderSpy).toHaveBeenCalledWith(
+        expect.any(Map),
+        mockFactory
+      );
+    });
+
+    it("should handle NestJS logger override gracefully when @nestjs/common is not available", async () => {
+      // This test ensures compile doesn't throw when NestJS is not available
+      await expect(testingModuleBuilder.compile()).resolves.toBeInstanceOf(ApplicationContext);
+    });
+  });
+
+  describe("private methods", () => {
+    describe("createModule", () => {
+      it("should create a module with the provided metadata", () => {
+        const metadata: ModuleMetadata = {
+          providers: [{ provide: "TEST", useValue: "test" }],
+          imports: [],
+          exports: [],
+        };
+        
+        const module = (testingModuleBuilder as any).createModule(metadata);
+        
+        expect(typeof module).toBe("function");
+        expect(module.name).toBe("RootTestModule");
+      });
+    });
+
+    describe("getModuleOverloads", () => {
+      it("should return empty array when no module overrides", () => {
+        const overrides = (testingModuleBuilder as any).getModuleOverloads();
+        
+        expect(overrides).toEqual([]);
+      });
+
+      it("should return module overrides in correct format", () => {
+        @Module({})
+        class OriginalModule {}
+        
+        @Module({})
+        class ReplacementModule {}
+        
+        testingModuleBuilder.overrideModule(OriginalModule).useModule(ReplacementModule);
+        
+        const overrides = (testingModuleBuilder as any).getModuleOverloads();
+        
+        expect(overrides).toEqual([
+          {
+            moduleToReplace: OriginalModule,
+            newModule: ReplacementModule,
+          },
+        ]);
+      });
+    });
+
+    describe("getRootModule", () => {
+      it("should return the first module from container", () => {
+        const mockModulesMap = new Map();
+        const mockModule = { test: "module" };
+        mockModulesMap.set("key", mockModule);
+
+        // @ts-expect-error Mismatch types
+        const containerSpy = spyOn(VenokContainer.prototype, "getModules").mockReturnValue(mockModulesMap);
+        
+        const rootModule = (testingModuleBuilder as any).getRootModule();
+        
+        expect(containerSpy).toHaveBeenCalled();
+        expect(rootModule).toBe(mockModule);
+      });
+    });
+
+    describe("applyOverloadsMap", () => {
+      it("should call container.replace for each override", () => {
+        const mockValue = { test: "value" };
+        const replaceSpy = spyOn(VenokContainer.prototype, "replace");
+        
+        testingModuleBuilder.overrideProvider("TEST_TOKEN").useValue(mockValue);
+        
+        (testingModuleBuilder as any).applyOverloadsMap();
+        
+        expect(replaceSpy).toHaveBeenCalledWith("TEST_TOKEN", {
+          useValue: mockValue,
+          isProvider: true,
+        });
+      });
+    });
+  });
+});

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "baseUrl": "./",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "NodeNext",
+    "verbatimModuleSyntax": true,
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "rootDir": "./",
+    "outDir": "./dist",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
+  },
+  "include": ["./src/*.ts", "./src/**/*.ts", "./test/**/*.ts"]
+}

--- a/scripts/ci-cd/get-packages-for-matrix.ts
+++ b/scripts/ci-cd/get-packages-for-matrix.ts
@@ -2,4 +2,4 @@ import BunLock from "../../bun.lock";
 
 const paths = Object.keys(BunLock.workspaces).slice(1);
 
-console.log(paths);
+console.log(JSON.stringify(paths));

--- a/scripts/tools/build.ts
+++ b/scripts/tools/build.ts
@@ -79,7 +79,7 @@ export const normalizePath = (str: string) => str.split("\\").join("/");
 
 const main = async () => {
   // const entries = Object.keys(BunLock.workspaces).slice(1);
-  const entries = ["packages/core", "packages/integration", "packages/http", "packages/microservices", "packages/websocket"];
+  const entries = ["packages/core", "packages/integration", "packages/testing", "packages/http", "packages/microservices", "packages/websocket"];
 
   if (entries.length === 0) throw new Error(`Workspaces not found.`);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The Venok framework lacked a dedicated testing package to facilitate unit testing and integration testing of modules, providers, and dependencies. Developers had to manually set up test environments without proper testing utilities for mocking, overriding providers, and creating isolated testing modules.

## What is the new behavior?

This PR introduces a comprehensive `@venok/testing` package that provides:

- `TestingModuleBuilder`: A fluent API for creating isolated testing modules with the ability to override providers, guards, pipes, filters, interceptors, and entire modules
- Test class: Main entry point with `createTestingModule()` method for initiating test module creation
- Provider/Dependency Overriding: Support for overriding any provider with custom values, factories, or classes
- Mock Factory Integration: Built-in support for auto-mocking with configurable mock factories
- Testing Utilities: Specialized injector, instance loader, and logger for testing environments
- Core Integration: Added missing `InstanceLoader `export to core package for testing functionality

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
