### PR TITLE
fix(http, websockets): Pass context type to proxy in context creator

### DIFF
--- a/packages/http/src/http/context.ts
+++ b/packages/http/src/http/context.ts
@@ -65,7 +65,7 @@ export class HttpContextCreator extends VenokContextCreator {
       filters: false,
       callback: undefined,
     },
-    contextType: TContext = "native" as TContext
+    contextType: TContext = "http" as TContext
   ): (...args: any[]) => Promise<any> {
     const moduleKey = this.getContextModuleKey(instance.constructor);
     const { getParamsMetadata } = super.getMetadata(
@@ -106,7 +106,7 @@ export class HttpContextCreator extends VenokContextCreator {
     );
 
     const exceptionFilter = this.filtersContextCreator.create(instance, callback, moduleKey, contextId, inquirerId);
-    return this.venokProxy.createProxy(result, exceptionFilter);
+    return this.venokProxy.createProxy(result, exceptionFilter, contextType);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/http/test/http/context.test.ts
+++ b/packages/http/test/http/context.test.ts
@@ -84,18 +84,18 @@ describe("HttpContextCreator", () => {
     } as any;
 
     contextCreator = new HttpContextCreator(
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+       
       mockGuardsContextCreator,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+       
       mockGuardsConsumer,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+       
       mockInterceptorsContextCreator,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+       
       mockInterceptorsConsumer,
       mockModulesContainer,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+       
       mockPipesContextCreator,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+       
       mockPipesConsumer,
       mockFiltersContextCreator
     );
@@ -173,7 +173,7 @@ describe("HttpContextCreator", () => {
           filters: false,
           callback: expect.any(Function),
         }),
-        "native"
+        "http"
       );
     });
 

--- a/packages/websocket/src/websocket/context.ts
+++ b/packages/websocket/src/websocket/context.ts
@@ -46,7 +46,7 @@ export class WebsocketContextCreator extends VenokContextCreator {
     return async (...args: any[]) => {
       args.push(targetPattern);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      return await this.venokProxy.createProxy(result, exceptionFilter)(...args);
+      return await this.venokProxy.createProxy(result, exceptionFilter, contextType)(...args);
     };
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The HTTP and WebSocket context creators were not properly passing the context type parameter to the proxy when creating execution contexts. The HTTP context creator was defaulting to "native" context type instead of "http", and both HTTP and WebSocket creators were not forwarding the context type to the `venokProxy.createProxy` method.

## What is the new behavior?

- HTTP context creator now defaults to "http" context type instead of "native"
- Both HTTP and WebSocket context creators now properly pass the `contextType` parameter to the `venokProxy.createProxy` method
- This ensures that execution context receives the correct context type information for proper request handling and proxy behavior

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This fix ensures that the proxy layer receives the correct context type information, which is essential for proper request routing and context-aware processing in both HTTP and WebSocket modules. The changes are minimal and focused on parameter passing consistency across the codebase.