### PR TITLE
fix(http): Close http adapter `onApplicationShutdown`

### DIFF
--- a/packages/http/src/http/starter-module.ts
+++ b/packages/http/src/http/starter-module.ts
@@ -1,4 +1,4 @@
-import type { OnApplicationBootstrap, OnModuleInit } from "@venok/core";
+import type { OnApplicationBootstrap, OnApplicationShutdown, OnModuleInit } from "@venok/core";
 
 import type { ControllerDiscovery } from "~/helpers/discovery.helper.js";
 import type { AbstractHttpAdapter } from "~/http/adapter.js";
@@ -24,7 +24,7 @@ import { Controller } from "~/decorators/controller.decorator.js";
 import { VENOK_HTTP_SERVER_START } from "~/helpers/messages.helper.js";
 
 @Injectable()
-export class HttpStarterModule<T extends HttpAppOptions = any> implements OnApplicationBootstrap, OnModuleInit {
+export class HttpStarterModule<T extends HttpAppOptions = any> implements OnApplicationShutdown, OnApplicationBootstrap, OnModuleInit {
   private readonly logger = new Logger(HttpStarterModule.name, { timestamp: true });
   private adapter!: AbstractHttpAdapter;
 
@@ -35,6 +35,10 @@ export class HttpStarterModule<T extends HttpAppOptions = any> implements OnAppl
     private readonly container: VenokContainer,
     private readonly httpConfig: HttpConfig
   ) {}
+
+  public async onApplicationShutdown() {
+    await this.adapter.close();
+  }
 
   public async onApplicationBootstrap() {
     const routes = this.adapter[VENOK_ADAPTER_BUILD]();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The HTTP adapter was not properly closing during application shutdown, potentially causing resource leaks and preventing clean application termination. The `HttpStarterModule` class only implemented `OnApplicationBootstrap` and `OnModuleInit` lifecycle hooks but was missing the `OnApplicationShutdown` hook to handle graceful server closure.

Issue Number: N/A


## What is the new behavior?

The HTTP adapter now properly closes during application shutdown. The `HttpStarterModule` class now implements the `OnApplicationShutdown` interface and includes an `onApplicationShutdown()` method that calls `await this.adapter.close()` to ensure the HTTP server is gracefully closed when the application shuts down.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This fix ensures proper resource cleanup and prevents potential memory leaks or hanging connections when the Venok application terminates. The change adds the missing lifecycle hook implementation to properly manage the HTTP adapter's lifecycle.