### PR TITLE
fix(websockets): Remove request scope support

### DIFF
--- a/packages/websocket/src/websocket/explorer.ts
+++ b/packages/websocket/src/websocket/explorer.ts
@@ -37,7 +37,7 @@ export class WebsocketExplorerService extends ExplorerService<WebsocketGatewayMe
   protected getSettings(): ExplorerSettings {
     return {
       contextType: "websocket",
-      isRequestScopeSupported: true,
+      isRequestScopeSupported: false,
       exceptionsFilterClass: WebsocketExceptionFiltersContext,
       contextCreatorClass: WebsocketContextCreator,
       options: { guards: true, interceptors: true, filters: false },

--- a/packages/websocket/test/websocket/explorer.test.ts
+++ b/packages/websocket/test/websocket/explorer.test.ts
@@ -260,7 +260,7 @@ describe("WebsocketExplorerService", () => {
 
       expect(settings).toEqual({
         contextType: "websocket",
-        isRequestScopeSupported: true,
+        isRequestScopeSupported: false,
         exceptionsFilterClass: WebsocketExceptionFiltersContext,
         contextCreatorClass: WebsocketContextCreator,
         options: { guards: true, interceptors: true, filters: false },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The WebSocket explorer service was configured with `isRequestScopeSupported: true`, which incorrectly indicated that WebSocket connections support request-scoped providers. This could lead to unexpected behavior since WebSocket connections are long-lived and don't follow the traditional request-response pattern where request scope would be appropriate.

## What is the new behavior?

The WebSocket explorer service now correctly sets `isRequestScopeSupported: false` in the explorer settings. This ensures that the WebSocket context properly reflects that request-scoped providers are not supported for WebSocket connections, preventing potential issues with dependency injection scope handling in long-lived WebSocket connections.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This change corrects an incorrect configuration and should not break existing functionality. Applications that were relying on request scope in WebSocket contexts were already operating under incorrect assumptions.

## Other information

This fix ensures consistency with the nature of WebSocket connections, which are stateful and long-lived, making request scope inappropriate. The change affects both the main implementation in `WebsocketExplorerService` and updates the corresponding test expectations to match the corrected behavior.