### PR TITLE
fix(http, microservices)!: Apply request scope to instances correctly

### DIFF
--- a/packages/http/src/constants.ts
+++ b/packages/http/src/constants.ts
@@ -5,3 +5,4 @@ export const REDIRECT_METADATA = "__redirect__";
 export const RESPONSE_PASSTHROUGH_METADATA = "__responsePassthrough__";
 export const VERSION_METADATA = "__version__";
 export const METHOD_METADATA = "method";
+export const CONTROLLER_METADATA = "controller";

--- a/packages/http/src/helpers/discovery.helper.ts
+++ b/packages/http/src/helpers/discovery.helper.ts
@@ -1,8 +1,4 @@
-import type { ScopeOptions } from "@venok/core";
-
 import type { AdapterRouteMetadata, VersionValue } from "~/interfaces/index.js";
-
-import { SCOPE_OPTIONS_METADATA } from "@venok/core";
 
 import { HOST_METADATA, PATH_METADATA, VERSION_METADATA } from "~/constants.js";
 
@@ -38,7 +34,6 @@ export class RouteDiscovery extends VenokBaseDiscovery<AdapterRouteMetadata & { 
 type ControllerDiscoveryMeta = {
   [PATH_METADATA]: string | string[];
   [HOST_METADATA]: string | RegExp | (string | RegExp)[] | undefined;
-  [SCOPE_OPTIONS_METADATA]: ScopeOptions | undefined;
   [VERSION_METADATA]: VersionValue | undefined;
 };
 
@@ -59,10 +54,6 @@ export class ControllerDiscovery extends VenokBaseDiscovery<ControllerDiscoveryM
 
   public getHost() {
     return this.meta[HOST_METADATA];
-  }
-
-  public getScope() {
-    return this.meta[SCOPE_OPTIONS_METADATA];
   }
 
   public getVersion() {

--- a/packages/http/src/http/explorer.ts
+++ b/packages/http/src/http/explorer.ts
@@ -18,6 +18,7 @@ import { HttpExceptionFiltersContext } from "~/filters/context.js";
 import { HttpContextCreator } from "~/http/context.js";
 import { HttpConfig } from "~/http/config.js";
 import { CONTROLLER_MAPPING_MESSAGE, ROUTE_MAPPED_MESSAGE, VERSIONED_CONTROLLER_MAPPING_MESSAGE, VERSIONED_ROUTE_MAPPED_MESSAGE } from "~/helpers/messages.helper.js";
+import { CONTROLLER_METADATA } from "~/constants.js";
 
 export class HttpExplorerService extends ExplorerService<ControllerDiscovery> implements OnModuleInit {
   /* Abstract */
@@ -49,7 +50,9 @@ export class HttpExplorerService extends ExplorerService<ControllerDiscovery> im
   protected filterProperties(wrapper: InstanceWrapper, metadataKey: string) {
     if (!wrapper.metatype) return;
 
-    const controllerDiscovery = this.get<ControllerDiscovery>(metadataKey, wrapper.metatype);
+    if (this.get<boolean>(metadataKey, wrapper.metatype)) return;
+
+    const controllerDiscovery = this.get<ControllerDiscovery>(CONTROLLER_METADATA, wrapper.metatype);
     if (!controllerDiscovery) return;
 
     const info = this.routeFinder.getControllerInfo(controllerDiscovery, this.httpConfig);

--- a/packages/http/test/decorators/controller.test.ts
+++ b/packages/http/test/decorators/controller.test.ts
@@ -3,18 +3,18 @@ import { describe, expect, it } from "bun:test";
 import { Scope } from "@venok/core";
 import { Controller } from "~/decorators/controller.decorator.js";
 import { ControllerDiscovery } from "~/helpers/discovery.helper.js";
+import { CONTROLLER_METADATA } from "~/constants.js";
 
 describe("@Controller", () => {
   it("should enhance class with expected controller metadata when no options provided", () => {
     @Controller()
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery).toBeInstanceOf(ControllerDiscovery);
     expect(discovery.getPrefixes()).toBe("/");
     expect(discovery.getHost()).toBeUndefined();
-    expect(discovery.getScope()).toBeUndefined();
     expect(discovery.getVersion()).toBeUndefined();
   });
 
@@ -22,12 +22,11 @@ describe("@Controller", () => {
     @Controller("api")
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery).toBeInstanceOf(ControllerDiscovery);
     expect(discovery.getPrefixes()).toBe("api");
     expect(discovery.getHost()).toBeUndefined();
-    expect(discovery.getScope()).toBeUndefined();
     expect(discovery.getVersion()).toBeUndefined();
   });
 
@@ -35,12 +34,11 @@ describe("@Controller", () => {
     @Controller(["api", "v1"])
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery).toBeInstanceOf(ControllerDiscovery);
     expect(discovery.getPrefixes()).toEqual(["api", "v1"]);
     expect(discovery.getHost()).toBeUndefined();
-    expect(discovery.getScope()).toBeUndefined();
     expect(discovery.getVersion()).toBeUndefined();
   });
 
@@ -54,12 +52,11 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery).toBeInstanceOf(ControllerDiscovery);
     expect(discovery.getPrefixes()).toBe("api/users");
     expect(discovery.getHost()).toBe("example.com");
-    expect(discovery.getScope()).toEqual({ scope: Scope.REQUEST, durable: true });
     expect(discovery.getVersion()).toBe("1");
   });
 
@@ -69,7 +66,7 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery.getPrefixes()).toBe("/");
     expect(discovery.getHost()).toBe("example.com");
@@ -82,7 +79,7 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery.getHost()).toBe("api.example.com");
   });
@@ -96,7 +93,7 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery.getHost()).toBe(hostRegex);
   });
@@ -110,7 +107,7 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery.getHost()).toEqual(hostArray);
   });
@@ -122,7 +119,7 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery.getVersion()).toEqual(["1", "2", "3"]);
   });
@@ -134,7 +131,7 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery.getVersion()).toBe("1.0");
   });
@@ -149,22 +146,9 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     // @ts-expect-error Mismatch types
     expect(discovery.getVersion()).toBe(versionSymbol);
-  });
-
-  it("should handle all scope options", () => {
-    @Controller({
-      path: "api",
-      scope: Scope.TRANSIENT,
-      durable: false,
-    })
-    class TestController {}
-
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
-    
-    expect(discovery.getScope()).toEqual({ scope: Scope.TRANSIENT, durable: false });
   });
 
   it("should handle mixed options", () => {
@@ -176,11 +160,10 @@ describe("@Controller", () => {
     })
     class TestController {}
 
-    const discovery = Reflect.getMetadata(Controller.KEY, TestController) as ControllerDiscovery;
+    const discovery = Reflect.getMetadata(CONTROLLER_METADATA, TestController) as ControllerDiscovery;
     
     expect(discovery.getPrefixes()).toEqual(["api", "v2"]);
     expect(discovery.getHost()).toEqual(/.*\.staging\.com$/);
-    expect(discovery.getScope()).toEqual({ scope: Scope.REQUEST, durable: undefined });
     expect(discovery.getVersion()).toEqual(["2", "3"]);
   });
 

--- a/packages/http/test/helpers/discovery.test.ts
+++ b/packages/http/test/helpers/discovery.test.ts
@@ -1,7 +1,6 @@
 import type { AdapterRouteMetadata } from "~/interfaces/index.js";
 
 import { beforeEach, describe, expect, it } from "bun:test";
-import { Scope, SCOPE_OPTIONS_METADATA } from "@venok/core";
 
 import { ControllerDiscovery, RouteDiscovery, VenokBaseDiscovery } from "~/helpers/discovery.helper.js";
 import { HOST_METADATA, PATH_METADATA, VERSION_METADATA } from "~/constants.js";
@@ -141,7 +140,6 @@ describe("Discovery Helper", () => {
       mockMeta = {
         [PATH_METADATA]: "/users",
         [HOST_METADATA]: "api.example.com",
-        [SCOPE_OPTIONS_METADATA]: { scope: Scope.REQUEST, durable: true },
         [VERSION_METADATA]: "1",
       };
 
@@ -162,9 +160,6 @@ describe("Discovery Helper", () => {
       expect(controllerDiscovery.getHost()).toBe("api.example.com");
     });
 
-    it("should get scope", () => {
-      expect(controllerDiscovery.getScope()).toEqual({ scope: Scope.REQUEST, durable: true });
-    });
 
     it("should get version", () => {
       expect(controllerDiscovery.getVersion()).toBe("1");
@@ -174,7 +169,6 @@ describe("Discovery Helper", () => {
       const arrayMeta = {
         [PATH_METADATA]: ["/users", "/api/users"],
         [HOST_METADATA]: undefined,
-        [SCOPE_OPTIONS_METADATA]: undefined,
         [VERSION_METADATA]: undefined,
       };
 
@@ -187,7 +181,6 @@ describe("Discovery Helper", () => {
       const regexMeta = {
         [PATH_METADATA]: "/users",
         [HOST_METADATA]: hostRegex,
-        [SCOPE_OPTIONS_METADATA]: undefined,
         [VERSION_METADATA]: undefined,
       };
 
@@ -200,7 +193,6 @@ describe("Discovery Helper", () => {
       const arrayHostMeta = {
         [PATH_METADATA]: "/users",
         [HOST_METADATA]: hostArray,
-        [SCOPE_OPTIONS_METADATA]: undefined,
         [VERSION_METADATA]: undefined,
       };
 
@@ -212,7 +204,6 @@ describe("Discovery Helper", () => {
       const versionMeta = {
         [PATH_METADATA]: "/users",
         [HOST_METADATA]: undefined,
-        [SCOPE_OPTIONS_METADATA]: undefined,
         [VERSION_METADATA]: ["1", "2", "3"],
       };
 
@@ -225,7 +216,6 @@ describe("Discovery Helper", () => {
       const symbolMeta = {
         [PATH_METADATA]: "/users",
         [HOST_METADATA]: undefined,
-        [SCOPE_OPTIONS_METADATA]: undefined,
         [VERSION_METADATA]: symbolVersion,
       };
 
@@ -239,7 +229,6 @@ describe("Discovery Helper", () => {
       const undefinedMeta = {
         [PATH_METADATA]: undefined,
         [HOST_METADATA]: undefined,
-        [SCOPE_OPTIONS_METADATA]: undefined,
         [VERSION_METADATA]: undefined,
       };
 
@@ -247,21 +236,9 @@ describe("Discovery Helper", () => {
       const discovery = new ControllerDiscovery(undefinedMeta);
       expect(discovery.getPrefixes()).toBeUndefined();
       expect(discovery.getHost()).toBeUndefined();
-      expect(discovery.getScope()).toBeUndefined();
       expect(discovery.getVersion()).toBeUndefined();
     });
 
-    it("should handle different scope options", () => {
-      const transientMeta = {
-        [PATH_METADATA]: "/users",
-        [HOST_METADATA]: undefined,
-        [SCOPE_OPTIONS_METADATA]: { scope: Scope.TRANSIENT, durable: false },
-        [VERSION_METADATA]: undefined,
-      };
-
-      const discovery = new ControllerDiscovery(transientMeta);
-      expect(discovery.getScope()).toEqual({ scope: Scope.TRANSIENT, durable: false });
-    });
 
     describe("Route Items Management", () => {
       it("should start with empty items", () => {
@@ -346,7 +323,6 @@ describe("Discovery Helper", () => {
       const controllerMeta = {
         [PATH_METADATA]: "/api/users",
         [HOST_METADATA]: "api.example.com",
-        [SCOPE_OPTIONS_METADATA]: { scope: Scope.REQUEST },
         [VERSION_METADATA]: ["1", "2"],
       };
 
@@ -393,7 +369,6 @@ describe("Discovery Helper", () => {
       const minimalMeta = {
         [PATH_METADATA]: "/",
         [HOST_METADATA]: undefined,
-        [SCOPE_OPTIONS_METADATA]: undefined,
         [VERSION_METADATA]: undefined,
       };
 
@@ -401,7 +376,6 @@ describe("Discovery Helper", () => {
 
       expect(controller.getPrefixes()).toBe("/");
       expect(controller.getHost()).toBeUndefined();
-      expect(controller.getScope()).toBeUndefined();
       expect(controller.getVersion()).toBeUndefined();
       expect(controller.getItems()).toEqual([]);
     });

--- a/packages/http/test/http/explorer.test.ts
+++ b/packages/http/test/http/explorer.test.ts
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unused-vars */
-import type { InstanceWrapper, Type, VenokContainer, VenokParamsFactoryInterface } from "@venok/core";
+import type { InstanceWrapper, VenokContainer, VenokParamsFactoryInterface } from "@venok/core";
 
-import type { VersioningOptions, VersionValue } from "~/interfaces/index.js";
+import type { VersioningOptions } from "~/interfaces/index.js";
 
-import { Inject, Logger, MetadataScanner, MODULE_PATH, Reflector } from "@venok/core";
+import { Logger, MetadataScanner, MODULE_PATH, Reflector } from "@venok/core";
 import { DiscoveryService, ExplorerService } from "@venok/integration";
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { pathToRegexp } from "path-to-regexp";
 
 import { VERSION_NEUTRAL } from "~/interfaces/index.js";
 import { HttpExplorerService } from "~/http/explorer.js";
@@ -206,9 +205,10 @@ describe("HttpExplorerService", () => {
 
       controllerDiscovery = new ControllerDiscovery({} as any);
 
-      // Mock the get method to return controller discovery
+      // Mock the get method to handle both metadata key check and CONTROLLER_METADATA
       spyOn(explorerService as any, "get").mockImplementation((metadataKey: any, metatype: typeof TestController) => {
-        if (metatype === TestController) return controllerDiscovery;
+        if (metadataKey === "test-key" && metatype === TestController) return false; // Not already processed
+        if (metadataKey === "controller" && metatype === TestController) return controllerDiscovery;
         return undefined;
       });
 
@@ -247,7 +247,23 @@ describe("HttpExplorerService", () => {
     });
 
     it("should return undefined when no controller discovery found", () => {
-      spyOn(explorerService as any, "get").mockReturnValue(undefined);
+      spyOn(explorerService as any, "get").mockImplementation((metadataKey: any) => {
+        if (metadataKey === "test-key") return false;
+        if (metadataKey === "controller") return undefined;
+        return undefined;
+      });
+      
+      const result = (explorerService as any).filterProperties(testWrapper, "test-key");
+      
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined when already processed", () => {
+      spyOn(explorerService as any, "get").mockImplementation((metadataKey: any) => {
+        if (metadataKey === "test-key") return true; // Already processed
+        if (metadataKey === "controller") return controllerDiscovery;
+        return undefined;
+      });
       
       const result = (explorerService as any).filterProperties(testWrapper, "test-key");
       
@@ -589,7 +605,11 @@ describe("HttpExplorerService", () => {
       const controllerDiscovery = new ControllerDiscovery({} as any);
 
       // Setup complete mocks
-      spyOn(explorerService as any, "get").mockReturnValue(controllerDiscovery);
+      spyOn(explorerService as any, "get").mockImplementation((metadataKey: any) => {
+        if (metadataKey === "test-key") return false;
+        if (metadataKey === "controller") return controllerDiscovery;
+        return undefined;
+      });
       spyOn(routeFinder, "getControllerInfo").mockReturnValue({
         prefixes: ["/api/test"],
         version: "1.0",
@@ -658,7 +678,11 @@ describe("HttpExplorerService", () => {
       } as any;
 
       const controllerDiscovery = new ControllerDiscovery({} as any);
-      spyOn(explorerService as any, "get").mockReturnValue(controllerDiscovery);
+      spyOn(explorerService as any, "get").mockImplementation((metadataKey: any) => {
+        if (metadataKey === "test-key") return false;
+        if (metadataKey === "controller") return controllerDiscovery;
+        return undefined;
+      });
       spyOn(routeFinder, "getControllerInfo").mockImplementation(() => {
         throw new Error("Route finder error");
       });
@@ -676,7 +700,11 @@ describe("HttpExplorerService", () => {
       } as any;
 
       const controllerDiscovery = new ControllerDiscovery({} as any);
-      spyOn(explorerService as any, "get").mockReturnValue(controllerDiscovery);
+      spyOn(explorerService as any, "get").mockImplementation((metadataKey: any) => {
+        if (metadataKey === "test-key") return false;
+        if (metadataKey === "controller") return controllerDiscovery;
+        return undefined;
+      });
       spyOn(routeFinder, "getControllerInfo").mockReturnValue({
         prefixes: ["/test"],
         version: undefined,
@@ -710,7 +738,11 @@ describe("HttpExplorerService", () => {
       } as any;
 
       const controllerDiscovery = new ControllerDiscovery({} as any);
-      spyOn(explorerService as any, "get").mockReturnValue(controllerDiscovery);
+      spyOn(explorerService as any, "get").mockImplementation((metadataKey: any) => {
+        if (metadataKey === "test-key") return false;
+        if (metadataKey === "controller") return controllerDiscovery;
+        return undefined;
+      });
       spyOn(routeFinder, "getControllerInfo").mockReturnValue({
         prefixes: ["/test"],
         version: undefined,
@@ -732,7 +764,11 @@ describe("HttpExplorerService", () => {
       } as any;
 
       const controllerDiscovery = new ControllerDiscovery({} as any);
-      spyOn(explorerService as any, "get").mockReturnValue(controllerDiscovery);
+      spyOn(explorerService as any, "get").mockImplementation((metadataKey: any) => {
+        if (metadataKey === "test-key") return false;
+        if (metadataKey === "controller") return controllerDiscovery;
+        return undefined;
+      });
       spyOn(routeFinder, "getControllerInfo").mockReturnValue({
         prefixes: ["/test"],
         version: undefined,
@@ -783,7 +819,11 @@ describe("HttpExplorerService", () => {
       } as any;
 
       const controllerDiscovery = new ControllerDiscovery({} as any);
-      spyOn(explorerService as any, "get").mockReturnValue(controllerDiscovery);
+      spyOn(explorerService as any, "get").mockImplementation((metadataKey: any) => {
+        if (metadataKey === "test-key") return false;
+        if (metadataKey === "controller") return controllerDiscovery;
+        return undefined;
+      });
       spyOn(routeFinder, "getControllerInfo").mockReturnValue({
         prefixes: ["/test"],
         version: undefined,

--- a/packages/microservices/src/decorators/microservice.decorator.ts
+++ b/packages/microservices/src/decorators/microservice.decorator.ts
@@ -1,4 +1,19 @@
-import { Reflector } from "@venok/core";
+import type { ScopeOptions } from "@venok/core";
+
+import { Reflector, Scope, SCOPE_OPTIONS_METADATA } from "@venok/core";
 
 
-export const Microservice = Reflector.createDecorator({ type: "class" });
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface MicroserviceOptions extends ScopeOptions {}
+
+type MicroserviceDecorator = {
+  [SCOPE_OPTIONS_METADATA]: { scope: Scope | undefined; durable: boolean | undefined; } | undefined,
+};
+
+export const Microservice = Reflector.createMetadataDecorator<MicroserviceOptions, MicroserviceDecorator>({ 
+  type: "class",
+  transform(options) {
+    const scope = { scope: options?.scope || Scope.DEFAULT, durable: options?.durable || false };
+    return { [SCOPE_OPTIONS_METADATA]: scope };
+  },
+});

--- a/packages/microservices/test/decorators/microservice.test.ts
+++ b/packages/microservices/test/decorators/microservice.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { Scope, SCOPE_OPTIONS_METADATA } from "@venok/core";
+
+import { Microservice } from "~/decorators/microservice.decorator.js";
+
+describe("@Microservice", () => {
+  it("should set default scope metadata when no options provided", () => {
+    @Microservice()
+    class TestMicroservice {}
+
+    const scopeOptions = Reflect.getMetadata(SCOPE_OPTIONS_METADATA, TestMicroservice);
+    
+    expect(scopeOptions).toEqual({ scope: Scope.DEFAULT, durable: false });
+  });
+
+  it("should set scope metadata when scope option provided", () => {
+    @Microservice({ scope: Scope.REQUEST })
+    class TestMicroservice {}
+
+    const scopeOptions = Reflect.getMetadata(SCOPE_OPTIONS_METADATA, TestMicroservice);
+    
+    expect(scopeOptions).toEqual({ scope: Scope.REQUEST, durable: false });
+  });
+
+  it("should set durable metadata when durable option provided", () => {
+    @Microservice({ durable: true })
+    class TestMicroservice {}
+
+    const scopeOptions = Reflect.getMetadata(SCOPE_OPTIONS_METADATA, TestMicroservice);
+    
+    expect(scopeOptions).toEqual({ scope: Scope.DEFAULT, durable: true });
+  });
+
+  it("should set both scope and durable metadata when both options provided", () => {
+    @Microservice({ 
+      scope: Scope.TRANSIENT, 
+      durable: true, 
+    })
+    class TestMicroservice {}
+
+    const scopeOptions = Reflect.getMetadata(SCOPE_OPTIONS_METADATA, TestMicroservice);
+    
+    expect(scopeOptions).toEqual({ scope: Scope.TRANSIENT, durable: true });
+  });
+
+  it("should handle REQUEST scope with durable false", () => {
+    @Microservice({ 
+      scope: Scope.REQUEST, 
+      durable: false, 
+    })
+    class TestMicroservice {}
+
+    const scopeOptions = Reflect.getMetadata(SCOPE_OPTIONS_METADATA, TestMicroservice);
+    
+    expect(scopeOptions).toEqual({ scope: Scope.REQUEST, durable: false });
+  });
+
+  it("should have KEY property", () => {
+    expect(Microservice.KEY).toBeDefined();
+    expect(typeof Microservice.KEY).toBe("string");
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Previously, request scope options were incorrectly applied to controller instances. The scope metadata was stored and retrieved directly on the controller discovery object, which caused issues with proper dependency injection scoping in both HTTP controllers and microservice decorators.

## What is the new behavior?

Request scope is now properly applied to controller and microservice instances:

- **HTTP Controllers**: Scope metadata is now separated from controller discovery metadata and stored as a separate metadata entry using `SCOPE_OPTIONS_METADATA`
- **Microservices**: Added proper scope options support with default scope handling and metadata storage
- **Explorer Service**: Fixed metadata retrieval logic to properly distinguish between controller discovery metadata and processing flags
- **Discovery Helper**: Removed scope-related methods from `ControllerDiscovery` class as scope is now handled separately

The changes ensure that dependency injection container correctly applies request scoping to instances when decorators specify scope options.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

**Breaking Changes:**
- Removed `getScope()` method from `ControllerDiscovery` class
- Changed `Controller` decorator internal metadata structure (affects only internal framework code, not user API)
- Modified `Microservice` decorator to properly handle scope options instead of being a simple marker decorator

**Migration Path:**
- User-facing APIs remain unchanged - no migration required for application code
- Internal framework extensions should use `SCOPE_OPTIONS_METADATA` directly instead of `ControllerDiscovery.getScope()`

## Other information

This fix ensures proper request scoping behavior across both HTTP and microservices packages, resolving issues where instance scoping wasn't correctly applied to controllers and microservice handlers.